### PR TITLE
Allows more flexible $ref parsing. Allows yaml.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ ng-swagger-gen: A Swagger 2.0 code generator for Angular 4.3+
 ---
 
 This project is a NPM module that generates model interfaces and web service
-clients from a [Swagger 2.0](http://swagger.io/) JSON
+clients from a [Swagger 2.0](http://swagger.io/)
 [specification](http://swagger.io/specification/).
 The generated classes follow the principles of Angular 4.3+ projects.
 
@@ -38,9 +38,6 @@ The design principles are:
 
 Here are a few notes:
 
-- The descriptor must be in JSON format. If you have your Swagger file in
-  YAML format, use the [online swagger editor](http://editor.swagger.io) to
-  export the descriptor as JSON;
 - Each operation is assumed to have a single tag. If none is declared, a default
   of `Api` (configurable) is assumed. If multiple tags are declared, the first
   one is used;
@@ -59,6 +56,7 @@ Here are a few notes:
 
 ## Requirements
 The generator itself has very few requirements, basically
+[json-schema-ref-parser](https://www.npmjs.com/package/json-schema-ref-parser),
 [argparse](https://www.npmjs.com/package/argparse) and
 [mustache](https://www.npmjs.com/package/mustache).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,74 @@
         "sprintf-js": "1.0.3"
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "format-util": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
+      "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      }
+    },
+    "json-schema-ref-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-4.1.1.tgz",
+      "integrity": "sha512-lByoCHZ6H2zgb6NtsXIqtzQ+6Ji7iVqnrhWxsXLhF+gXmgu6E8+ErpDxCMR439MUG1nfMjWI2HAoM8l0XgSNhw==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "1.0.1",
+        "debug": "3.1.0",
+        "js-yaml": "3.11.0",
+        "ono": "4.0.3"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
     "mustache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.0.tgz",
       "integrity": "sha1-QCj3d4sXcIpImTCm5SrDvKDaQdA="
+    },
+    "ono": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.3.tgz",
+      "integrity": "sha512-7QIxG4UB00H7CR7fhXC/U7VhB5DK9wsYLwaYBui1JmQoXtLkhIBn3fbuk6FgAP+ctWeBsWVTM+R/bThvUZN+ww==",
+      "dev": true,
+      "requires": {
+        "format-util": "1.0.3"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   },
   "bin": {
     "ng-swagger-gen": "./ng-swagger-gen"
+  },
+  "devDependencies": {
+    "json-schema-ref-parser": "^4.1.1"
   }
 }


### PR DESCRIPTION
Hey, thanks for the great package.

For my use case I needed more extended $ref parsing, including local files and the likes. I realized it would be quite easy to drop in [json-schema-ref-parser](https://www.npmjs.com/package/json-schema-ref-parser) to handle the initial swagger parsing. As well as handling more $ref cases, the project should now be able to handle yaml files as well!

I also applied [prettier](https://github.com/prettier/prettier) but if you want I can roll that back.

I also have a feeling that It would be possible to remove some of the complexity in `processModels` and maybe `processServices` due to the way `json-schema-ref-parser` works, but I didn't have a go at that as I wasn't confident I wouldn't break something.

Anyway thanks again!