### PR TITLE
Add .forRoot() to ApiModule to prevent ApiConfiguration changes from being overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The files are:
 - **api/api.module.ts**: A module that declares an `NgModule` that provides all
   services. Your root application module
   should import this module to ensure all services are available via dependency
-  injection on your application. Use `ApiModule.forRoot()` in your root module to ensure the `ApiConfiguration` class is available in all modules.
+  injection on your application. Use `ApiModule.forRoot({rootUrl = 'http://yourwebserver'})` in your root module to ensure the `ApiConfiguration` class is available in all modules.
   In all the other modules, you should include the module without the `.forRoot()` to prevent the configuration from being overridden.
 
 ## Using a configuration file

--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ The files are:
   If the service root URL is `null`, which is the default, the service will use
   the global root URL defined in `ApiConfiguration`;
 - **api/api.module.ts**: A module that declares an `NgModule` that provides all
-  services, plus the `ApiConfiguration` instance. Your root application module
+  services. Your root application module
   should import this module to ensure all services are available via dependency
-  injection on your application. Use `ApiModule.forRoot()` in your root module. 
+  injection on your application. Use `ApiModule.forRoot()` in your root module to ensure the `ApiConfiguration` class is available in all modules.
   In all the other modules, you should include the module without the `.forRoot()` to prevent the configuration from being overridden.
 
 ## Using a configuration file

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ export const INIT_API_CONFIGURATION: Provider = {
     AppComponent
   ],
   imports: [
-    ApiModule
+    ApiModule.forRoot()
   ],
   providers: [
     INIT_API_CONFIGURATION

--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ The files are:
 - **api/api.module.ts**: A module that declares an `NgModule` that provides all
   services, plus the `ApiConfiguration` instance. Your root application module
   should import this module to ensure all services are available via dependency
-  injection on your application.
+  injection on your application. Use `ApiModule.forRoot()` in your root module. 
+  In all the other modules, you should include the module without the `.forRoot()` to prevent the configuration from being overridden.
 
 ## Using a configuration file
 On regular usage it is recommended to use a configuration file instead of

--- a/templates/apiModule.mustache
+++ b/templates/apiModule.mustache
@@ -24,7 +24,7 @@ import { ApiConfiguration } from './api-configuration';
   ],
 })
 export class ApiModule {
-    public static forRoot(apiConfiguration: ApiConfiguration = ApiConfiguration): ModuleWithProviders {
+    public static forRoot(apiConfiguration: ApiConfiguration): ModuleWithProviders {
     return {
       ngModule: ApiModule,
       providers: [ { provide: ApiConfiguration, useValue: apiConfiguration }]

--- a/templates/apiModule.mustache
+++ b/templates/apiModule.mustache
@@ -3,9 +3,10 @@ import { HttpClientModule } from '@angular/common/http';
 import { ModuleWithProviders } from '@angular/compiler/src/core';
 import { ApiConfiguration } from './api-configuration';
 
-
 {{#services}}import { {{serviceClass}} } from './services/{{serviceFile}}';
 {{/services}}
+
+export const DEFAULT_API_CONFIG: ApiConfiguration = new ApiConfiguration();
 
 /**
  * Module that provides instances for all API services
@@ -24,10 +25,10 @@ import { ApiConfiguration } from './api-configuration';
   ],
 })
 export class ApiModule {
-    public static forRoot(apiConfiguration: ApiConfiguration): ModuleWithProviders {
+    public static forRoot(apiConfiguration?: ApiConfiguration): ModuleWithProviders {
     return {
       ngModule: ApiModule,
-      providers: [ { provide: ApiConfiguration, useValue: apiConfiguration }]
+      providers: [ { provide: ApiConfiguration, useValue: apiConfiguration || DEFAULT_API_CONFIG }]
     }
   }
 }

--- a/templates/apiModule.mustache
+++ b/templates/apiModule.mustache
@@ -1,6 +1,8 @@
 import { NgModule } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
+import { ModuleWithProviders } from '@angular/compiler/src/core';
 import { ApiConfiguration } from './api-configuration';
+
 
 {{#services}}import { {{serviceClass}} } from './services/{{serviceFile}}';
 {{/services}}
@@ -17,9 +19,15 @@ import { ApiConfiguration } from './api-configuration';
   ],
   declarations: [],
   providers: [
-    ApiConfiguration,
 {{#services}}   {{serviceClass}}{{^serviceIsLast}},{{/serviceIsLast}}
 {{/services}}
   ],
 })
-export class ApiModule { }
+export class ApiModule {
+    public static forRoot(apiConfiguration: ApiConfiguration = ApiConfiguration): ModuleWithProviders {
+    return {
+      ngModule: ApiModule,
+      providers: [ { provide: ApiConfiguration, useValue: apiConfiguration }]
+    }
+  }
+}


### PR DESCRIPTION
In our application, we use `ApiModule` in multiple (sub-)modules. 
We included the `ApiModule` for each module, which caused the `ApiConfiguration` to be defaulted at every import. 

We changed the template so it will provide a `.forRoot()` method which should only be used at root. This way, each import that does not use `.forRoot()` will have the same configuration as specified in the root module.
