### PR TITLE
Added functionality to add Common Parameters for All Methods of a Path

### DIFF
--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -860,6 +860,7 @@ function processServices(swagger, models, options) {
   var minParamsForContainer = options.minParamsForContainer || 2;
   for (var url in swagger.paths) {
     var path = swagger.paths[url];
+	var methodParameters = path['parameters'];
     for (var method in path || {}) {
       var def = path[method];
       if (!def) {
@@ -887,6 +888,10 @@ function processServices(swagger, models, options) {
       );
 
       var parameters = def.parameters || [];
+
+      if (methodParameters) {
+        parameters = parameters.concat(methodParameters);
+      }
 
       var paramsClass = null;
       var paramsClassComments = null;


### PR DESCRIPTION
As described in the swagger specification (https://swagger.io/docs/specification/describing-parameters/) it is possible to provide Common Parameters for All Methods of a Path. I added that functionality.