### PR TITLE
Issue#100 - Prefix not working for configuration file

### DIFF
--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -249,7 +249,7 @@ function doGenerate(swagger, options) {
 
   // Write the BaseService
   {
-    generate(templates.baseService, {}, output + '/base-service.ts');
+    generate(templates.baseService, applyGlobals({}), output + '/base-service.ts');
   }
 }
 

--- a/templates/baseService.mustache
+++ b/templates/baseService.mustache
@@ -1,6 +1,6 @@
 /* tslint:disable */
 import { HttpClient, HttpParameterCodec, HttpParams } from '@angular/common/http';
-import { ApiConfiguration } from './api-configuration';
+import { {{ configurationClass }} } from './{{configurationFile}}';
 
 /**
  * Custom parameter codec to correctly handle the plus sign in parameter

--- a/templates/baseService.mustache
+++ b/templates/baseService.mustache
@@ -30,7 +30,7 @@ const PARAMETER_CODEC = new ParameterCodec();
  */
 export class BaseService {
   constructor(
-    protected config: ApiConfiguration,
+    protected config: {{ configurationClass }},
     protected http: HttpClient
   ) {
   }

--- a/templates/service.mustache
+++ b/templates/service.mustache
@@ -14,7 +14,7 @@ import { map as __map, filter as __filter } from 'rxjs/operators';
 })
 class {{serviceClass}} extends BaseService {
   constructor(
-    config: ApiConfiguration,
+    config: {{ configurationClass }},
     http: HttpClient
   ) {
     super(config, http);

--- a/templates/service.mustache
+++ b/templates/service.mustache
@@ -2,7 +2,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpRequest, HttpResponse, HttpHeaders, HttpParams } from '@angular/common/http';
 import { BaseService } from '../base-service';
-import { ApiConfiguration } from '../api-configuration';
+import { {{ configurationClass }} } from '../{{configurationFile}}';
 import { StrictHttpResponse } from '../strict-http-response';
 import { Observable } from 'rxjs';
 import { map as __map, filter as __filter } from 'rxjs/operators';


### PR DESCRIPTION
On base-service and service templates or the configuration file is hardcoded to ApiConfiguration and the ApiConfiguration ts file.

This was fixed on this commit.