### PR TITLE
Use the base path as the root url if host is undefined

### DIFF
--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -237,9 +237,10 @@ function doGenerate(swagger, options) {
   {
     var schemes = swagger.schemes || [];
     var scheme = schemes.length == 0 ? 'http' : schemes[0];
-    var host = swagger.host || 'localhost';
     var basePath = swagger.basePath || '/';
-    var rootUrl = scheme + '://' + host + basePath;
+    var rootUrl = swagger.host
+      ? scheme + '://' + swagger.host + basePath
+      : basePath.replace(/^\/?/, '/');
     generate(templates.configuration, applyGlobals({
         rootUrl: rootUrl,
       }),


### PR DESCRIPTION
the use case would be multiple environments using their own api