### PR TITLE
Fixed regex

### DIFF
--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -858,7 +858,7 @@ function toIdentifier(string) {
   var wasSep = false;
   for (var i = 0; i < string.length; i++) {
     var c = string.charAt(i);
-    if (/[a-z|A-Z|0-9]/.test(c)) {
+    if (/[a-zA-Z0-9]/.test(c)) {
       if (wasSep) {
         c = c.toUpperCase();
         wasSep = false;


### PR DESCRIPTION
Fixed regular expression, because `/[a-z|A-Z|0-9]/` will match "Abc123|||" string, for example. While we want to match only "Abc123".
So, I guess that someone has used "|" as "or" operator here, but regex is not JS, the "[]" already work as "or" here.