### PR TITLE
Fixed rootUrl generation

### DIFF
--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -235,17 +235,16 @@ function doGenerate(swagger, options) {
 
   // Write the configuration
   {
-    // Following code ported from io.swagger.codegen.DefaultGenerator#getHost (https://github.com/swagger-api/swagger-codegen)
-    var schemes = swagger.schemes || [];
-    var scheme = schemes.length === 0 ? 'https' : schemes[0];
+    // Following code ported from io.swagger.codegen.DefaultGenerator#getHost with some changes for issue #113
     var rootUrlBuilder = [];
-    rootUrlBuilder.push(scheme);
-    rootUrlBuilder.push('://');
     if (swagger.hasOwnProperty('host') && swagger.host !== '') {
+      var schemes = swagger.schemes || [];
+      var scheme = schemes.length === 0 ? 'https' : schemes[0];
+      rootUrlBuilder.push(scheme);
+      rootUrlBuilder.push('://');
       rootUrlBuilder.push(swagger.host);
     } else {
-      rootUrlBuilder.push('localhost');
-      console.warn('\'host\' not defined in the spec. Default to \'localhost\'.');
+      console.warn('\'host\' not defined in the spec. Default to relative basePath only.');
     }
     if (swagger.hasOwnProperty('basePath') && swagger.basePath !== '' && swagger.basePath !== '/') {
       rootUrlBuilder.push(swagger.basePath);


### PR DESCRIPTION
Fixed issue with `rootUrl`, mentioned in #118 issue.
Algorithm was ported from official [swagger-api/swagger-codegen](https://github.com/swagger-api/swagger-codegen) repo, [getHost()](https://github.com/swagger-api/swagger-codegen/blob/0d0cd9e454cb0c039841081d2ee4144a1eaefc2a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java#L109) function in particular.

Some of changes:
- Now if `host` is not specified, it will be set to `localhost` and warning will be produced.
- Default `scheme` is `https` now, instead of `http` in case if it wasn't specified.
- If `basePath` wasn't specified, it won't default to `/`.