### PR TITLE
Implement protocol agnostic urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ The supported properties in the JSON file are:
   section, will generate a corresponding `<model>.example.ts` file, exporting a
   function called `get<Model>Example()`, which will return the data present in
   the example section.
+- `defualtProtocol`: When the Swagger descriptor 'schema' property is null or empty the protocol will be assigned this value, otherwise    the first schema will be used. Note: you must supply the schema postfix IE `HTTP://`. Defaults to relative path `//`.
 
 ### Configuration file example
 The following is an example of a configuration file which will choose a few

--- a/ng-swagger-gen-schema.json
+++ b/ng-swagger-gen-schema.json
@@ -94,6 +94,11 @@
       "description": "Indicates whether or not to generate the example files from the example sections of the models. Defaults to false.",
       "type": "boolean",
       "default": "false"
+    },
+    "defaultProtocol": {
+       "description": "When the Swagger descriptor 'schema' property is null or empty the protocol will be assigned this value, otherwise the first schema will be used. Defaults to relative path '//'.",
+       "type": "string",
+       "default": "//"
     }
   }
 }

--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -236,7 +236,7 @@ function doGenerate(swagger, options) {
   // Write the configuration
   {
     var schemes = swagger.schemes || [];
-    var protocol = schemes.length == 0 ? '//' : schemes[0] + '://';
+    var protocol = schemes.length == 0 ? options.defaultProtocol : schemes[0] + '://';
     var basePath = swagger.basePath || '/';
     var rootUrl = swagger.host
       ? protocol + swagger.host + basePath

--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -236,14 +236,15 @@ function doGenerate(swagger, options) {
   // Write the configuration
   {
     var schemes = swagger.schemes || [];
-    var scheme = schemes.length == 0 ? 'http' : schemes[0];
+    var protocol = schemes.length == 0 ? '//' : schemes[0] + '://';
     var basePath = swagger.basePath || '/';
     var rootUrl = swagger.host
-      ? scheme + '://' + swagger.host + basePath
+      ? protocol + swagger.host + basePath
       : basePath.replace(/^\/?/, '/');
     generate(templates.configuration, applyGlobals({
         rootUrl: rootUrl,
       }),
+      
       path.join(output, configurationFile + '.ts')
     );
   }


### PR DESCRIPTION
when no schema(s) are supplied the rootUrl is now constructed without the scheme, e.g. "//url.example.com/api"