### PR TITLE
fix: Double underscore

### DIFF
--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -440,19 +440,19 @@ function simpleRef(ref) {
 function toEnumName(value) {
   var result = '';
   var wasLower = false;
+  value = value.replace(/[^\w]/g, '_');
   for (var i = 0; i < value.length; i++) {
     var c = value.charAt(i);
-    var isLower = /[a-z]/.test(c);
-    if (!isLower && wasLower) {
+    var isLowerOrUScore = /[a-z_]/.test(c);
+    if (!isLowerOrUScore && wasLowerOrUScore) {
       result += '_';
     }
     result += c.toUpperCase();
-    wasLower = isLower;
+    wasLowerOrUScore = isLowerOrUScore;
   }
   if (!isNaN(value[0])) {
     result = '_' + result;
   }
-  result = result.replace(/[^\w]/g, '_');
   return result;
 }
 


### PR DESCRIPTION
Hi,

I use swagger contract to describe a backend and use maven swagger generator to create java classes.
If an enum have space or accent (é, à, ...) the java enum looks like :
Enum with space => ENUM_WITH_SPACE

To do the same generation for an angular front-end, I tried your code. Everything works great for me except for enum which looks like :
Enum with space => ENUM__WITH__SPACE

So I, quickly, corrected 'toEnumName' function to feet my need and propose my pull request.