### PR TITLE
added support for anyOf/oneOf for definitions

### DIFF
--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -700,7 +700,13 @@ function propertyType(property) {
     return type.length == 0 ? 'null' : type;
   } else if(property['x-nullable']) {
     return 'null | ' + propertyType(Object.assign(property, {'x-nullable': undefined}));
-  }  
+  } else if (!property.type && (property.anyOf || property.oneOf)) {
+    let variants = (property.anyOf || property.oneOf).map(propertyType);
+    return {
+      allTypes: variants.map(variant => variant.allTypes || variant),
+      toString: () => variants.join(' | ')
+    };
+  }
   switch (property.type) {
     case 'string':
       if (property.enum && property.enum.length > 0) {


### PR DESCRIPTION
I know that swagger version 2.0 does not support anyOf/oneOf in definition of types, but JSON schema validator which is internally used in swagger tools does. Therefore swagger 3.0 also support this feature.

I have in `swagger-doc.yml` defined type like:
```yaml
...
definitions:
  Request:
    type: object
    properties:
      use_elevation:
        anyOf:
          - type: boolean
          - type: number
```
It generates:
```typescript
/* tslint:disable */
export interface Request {
  use_elevation?: any;
}
```
but expected is:
```typescript
/* tslint:disable */
export interface Request {
  use_elevation?: boolean | number;
}
```
To support this feature is quite simple.