### PR TITLE
Adding an option "rootUrl" in the config file

### DIFF
--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -248,6 +248,9 @@ function doGenerate(swagger, options) {
       && swagger.basePath !== '/') {
       rootUrl += swagger.basePath;
     }
+    if(options.rootUrl !== undefined){
+      rootUrl = options.rootUrl;
+    }
 
     generate(templates.configuration, applyGlobals({
         rootUrl: rootUrl,


### PR DESCRIPTION
I needed to have a rootUrl option for swagger services to work, so here is my proposal if you want to add it.
Maybe not complete but tested and it works.