### PR TITLE
Make rootUrl customization easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,39 +292,15 @@ the call to `ng-swagger-gen`, like:
 
 ## Specifying the root URL / web service endpoint
 The easiest way to specify a custom root URL (web service endpoint URL) is to
-inject the `ApiConfiguration` instance in some service and set the `rootUrl`
-property from there.
-
-Alternatively, define a provider for `APP_INITIALIZER` in your root module,
-like this:
+use `forRoot` method of `ApiModule` and set the `rootUrl` property from there.
 
 ```typescript
-export function initApiConfiguration(config: ApiConfiguration): Function {
-  return () => {
-    config.rootUrl = 'https://some-root-url.com';
-  };
-}
-export const INIT_API_CONFIGURATION: Provider = {
-  provide: APP_INITIALIZER,
-  useFactory: initApiConfiguration,
-  deps: [ApiConfiguration],
-  multi: true
-};
-
-/**
- * Then declare the provider. In this example, the AppModule is also
- * importing the ApiModule, which is important to get access to the
- * generated services
- */
 @NgModule({
   declarations: [
     AppComponent
   ],
   imports: [
-    ApiModule
-  ],
-  providers: [
-    INIT_API_CONFIGURATION
+    ApiModule.forRoot({rootUrl: 'https://some-root-url.com'}),
   ],
   bootstrap: [
     AppComponent

--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -103,6 +103,7 @@ function doGenerate(swagger, options) {
   // Angular's best practices demands xxx.module.ts, not xxx-module.ts
   moduleFile = moduleFile.replace(/\-module$/, '.module');
   var configurationClass = toClassName(prefix + 'Configuration');
+  var configurationInterface = toClassName(prefix + 'ConfigurationInterface');
   var configurationFile = toFileName(configurationClass);
 
   function applyGlobals(to) {
@@ -110,6 +111,7 @@ function doGenerate(swagger, options) {
     to.moduleClass = moduleClass;
     to.moduleFile = moduleFile;
     to.configurationClass = configurationClass;
+    to.configurationInterface = configurationInterface;
     to.configurationFile = configurationFile;
     return to;
   }

--- a/templates/configuration.mustache
+++ b/templates/configuration.mustache
@@ -10,3 +10,7 @@ import { Injectable } from '@angular/core';
 export class {{configurationClass}} {
   rootUrl: string = '{{{rootUrl}}}';
 }
+
+export interface {{configurationInterface}} {
+  rootUrl?: string;
+}

--- a/templates/module.mustache
+++ b/templates/module.mustache
@@ -1,7 +1,7 @@
 /* tslint:disable */
-import { NgModule } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
-import { {{configurationClass}} } from './{{configurationFile}}';
+import { {{configurationClass}}, {{configurationInterface}} } from './{{configurationFile}}';
 
 {{#services}}import { {{serviceClass}} } from './services/{{serviceFile}}';
 {{/services}}
@@ -23,4 +23,16 @@ import { {{configurationClass}} } from './{{configurationFile}}';
 {{/services}}
   ],
 })
-export class {{moduleClass}} { }
+export class {{moduleClass}} {
+  static forRoot(customParams: {{configurationInterface}}): ModuleWithProviders {
+    return {
+      ngModule: {{moduleClass}},
+      providers: [
+        {
+          provide: {{configurationClass}},
+          useValue: {rootUrl: customParams.rootUrl}
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Current implementation of `rootUrl` customization is not very user friendly.
With this changes you can use custom `rootUrl` much easier. Something like this:
```typescript
@NgModule({
  declarations: [
    AppComponent
  ],
  imports: [
    ApiModule.forRoot({rootUrl: 'https://some-root-url.com'}),
  ],
  bootstrap: [
    AppComponent
  ]
})
export class AppModule { }
```