### PR TITLE
Added support for hyphens in property names.

### DIFF
--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -841,7 +841,7 @@ function processProperties(swagger, properties, requiredProperties) {
   for (var name in properties) {
     var property = properties[name];
     var descriptor = {
-      propertyName: name,
+      propertyName: name.indexOf('-') === -1 ? name : `"${name}"`,
       propertyComments: toComments(property.description, 1),
       propertyRequired: requiredProperties.indexOf(name) >= 0,
       propertyType: propertyType(property),

--- a/templates/object.mustache
+++ b/templates/object.mustache
@@ -1,6 +1,6 @@
 {{{modelComments}}}export interface {{modelClass}} {{#modelParent}}extends {{modelName}} {{/modelParent}}{
 {{#modelProperties}}
-{{{propertyComments}}}{{propertyName}}{{^propertyRequired}}?{{/propertyRequired}}: {{{propertyType}}};
+{{{propertyComments}}}{{&propertyName}}{{^propertyRequired}}?{{/propertyRequired}}: {{{propertyType}}};
 {{/modelProperties}}
 {{#modelAdditionalPropertiesType}}
 


### PR DESCRIPTION
Our team has to support models that contain hyphens in property names. Typescript can handle that if they are wrapped in quotation marks. Unfortunately ng-swagger-gen does not do this by default, so these kind of models get generated.

```
export interface ExampleModel {
	...
	not-before-policy?: number;
	...
}
```

This does lead to compile errors. I upgraded the script and mustache template to support this use case. Would be nice to get some feedback