### PR TITLE
Add camelCase option

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ The supported properties in the JSON file are:
   section, will generate a corresponding `<model>.example.ts` file, exporting a
   function called `get<Model>Example()`, which will return the data present in
   the example section.
+- `camelCase`: Generates service methods in camelCase instead of PascalCase.
 
 ### Configuration file example
 The following is an example of a configuration file which will choose a few

--- a/ng-swagger-gen-schema.json
+++ b/ng-swagger-gen-schema.json
@@ -94,6 +94,11 @@
       "description": "Indicates whether or not to generate the example files from the example sections of the models. Defaults to false.",
       "type": "boolean",
       "default": "false"
+    },
+    "camelCase": {
+      "description": "Generates service methods in camelCase instead of PascalCase",
+      "type": "boolean",
+      "default": "false"
     }
   }
 }

--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -1150,8 +1150,12 @@ function processServices(swagger, models, options) {
       if (operationResponses.resultDescription) {
         docString += '\n@return ' + operationResponses.resultDescription;
       }
+      function getOperationName(string) {
+        if (options.camelCase) return string.charAt(0).toLowerCase() + string.slice(1);
+        else return string;
+      }
       var operation = {
-        operationName: id,
+        operationName: getOperationName(id),
         operationParamsClass: paramsClass,
         operationParamsClassComments: paramsClassComments,
         operationMethod: method.toLocaleUpperCase(),


### PR DESCRIPTION
The Angular style guide describes that methods in services should be in camelCase. Current ng-swagger-gen version generates methods in PascalCase.

I added the option `camelCase` to make possible generate methods in services in camelCase.
But default config still generates methods in PascalCase to have no breaking changes.