### PR TITLE
Fixes an issue where the status is NaN

### DIFF
--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -1229,16 +1229,18 @@ function processServices(swagger, models, options) {
       var op = service.serviceOperations[i];
       for (var code in op.operationResponses) {
         var status = Number(code);
-        var actualDeps = (status < 200 || status >= 300)
-          ? errorDependencies : dependencies;
-        var response = op.operationResponses[code];
-        if (response.type) {
-          var type = response.type;
-          if (type && type.allTypes) {
-            // This is an inline object. Append all types
-            type.allTypes.forEach(t => actualDeps.add(t));
-          } else {
-            actualDeps.add(type);
+        if (!isNaN(status)) {
+          var actualDeps = (status < 200 || status >= 300)
+            ? errorDependencies : dependencies;
+          var response = op.operationResponses[code];
+          if (response.type) {
+            var type = response.type;
+            if (type && type.allTypes) {
+              // This is an inline object. Append all types
+              type.allTypes.forEach(t => actualDeps.add(t));
+            } else {
+              actualDeps.add(type);
+            }
           }
         }
       }

--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -1233,7 +1233,7 @@ function processServices(swagger, models, options) {
           var actualDeps = (status < 200 || status >= 300)
             ? errorDependencies : dependencies;
           var response = op.operationResponses[code];
-          if (response.type) {
+          if (response && response.type) {
             var type = response.type;
             if (type && type.allTypes) {
               // This is an inline object. Append all types


### PR DESCRIPTION
Swagger to reproduce:

```json
{
"swagger": "2.0",
"info": {
"title": "My API",
"version": "v1"
},
"paths": {
"/api/FileUpload/{orderid}": {
"post": {
"tags": [
"FileUpload"
],
"operationId": "UploadOrderFile",
"produces": [
"text/plain"
],
"parameters": [
{
"in": "path",
"name": "orderid",
"required": true,
"type": "string",
"default": ""
}
],
"responses": {
"200": {
"description": "Success",
"schema": {
"type": "boolean"
}
}
}
}
},
"/api/Orders": {
"get": {
"tags": [
"Orders"
],
"operationId": "GetOrders",
"produces": [
"application/json"
],
"responses": {
"200": {
"schema": {
"description": "Success",
"uniqueItems": false,
"type": "array",
"items": {
"$ref": "#/definitions/spGetOrdersResult"
}
}
}
}
}
}
},
"definitions": {
"spGetOrdersResult": {
"type": "object",
"properties": {
"orderId": {
"type": "string"
},
"orderName": {
"type": "string"
},
"orderDate": {
"format": "date",
"type": "string"
}
}
}
}
}
```