### PR TITLE
[Feat] Allow to pass config as JS module file

### DIFF
--- a/ng-swagger-gen
+++ b/ng-swagger-gen
@@ -2,7 +2,7 @@
 'use strict';
 
 function parseJSON(file) {
-  return JSON.parse(fs.readFileSync(file, "utf8"));
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
 }
 
 const DEFAULT_CONFIG = 'ng-swagger-gen.json';
@@ -10,64 +10,64 @@ const SCHEMA = 'ng-swagger-gen-schema.json';
 const fs = require('fs');
 const path = require('path');
 const ArgumentParser = require('argparse').ArgumentParser;
-const pkg = parseJSON(path.join(__dirname, "package.json"));
+const pkg = parseJSON(path.join(__dirname, 'package.json'));
 const schema = parseJSON(path.join(__dirname, SCHEMA));
 
 var argParser = new ArgumentParser({
   version: pkg.version,
   addHelp: true,
-  description: "Swagger API client generator for Angular 2+ projects." +
-  " Either uses a configuration file (defaults to " + DEFAULT_CONFIG + ")" +
-  " in the current directory, but the file can be specified)" +
-  " allowing the program to be called without arguments, or the swagger input" +
-  " file must be specified. A configuration file can be generated with all" +
-  " default values if --gen-config is specified, together with the swagger" +
-  " input file, which is also required in this case."
+  description:
+    'Swagger API client generator for Angular 2+ projects.' +
+    ' Either uses a configuration file (defaults to ' +
+    DEFAULT_CONFIG +
+    ')' +
+    ' in the current directory, but the file can be specified)' +
+    ' allowing the program to be called without arguments, or the swagger input' +
+    ' file must be specified. A configuration file can be generated with all' +
+    ' default values if --gen-config is specified, together with the swagger' +
+    ' input file, which is also required in this case.',
 });
-argParser.addArgument(
-  ["-i", "--input", "-s", "--swagger"],
-  {
-    help: "The swagger input file or URL. If not specified, it is required" +
-    " that a configuration file called " + DEFAULT_CONFIG +
-    " exist in the current directory, or a configuration file can be" +
-    " specified with the -c or --config option.",
-    dest: "swagger",
-    metavar: "SWAGGER"
-  }
-);
-argParser.addArgument(
-  ["-o", "--output"],
-  {
-    help: "The root directory where files will be generated.",
-    dest: "output"
-  }
-);
-argParser.addArgument(
-  ["-c", "--config"],
-  {
-    help: "Specifies the configuration file name.",
-    defaultValue: DEFAULT_CONFIG,
-    dest: "config"
-  }
-);
-argParser.addArgument(
-  ["--gen-config"],
-  {
-    help: "Generates the configuration file " + DEFAULT_CONFIG +
-    " in the current directory, or the file specified with -c or --config." +
-    " No Swagger client classes are generated." +
-    " If input and output are specified, their values are stored in the" +
-    " generated file as well.",
-    action: "storeTrue",
-    dest: "genConfig"
-  }
-);
+argParser.addArgument(['-i', '--input', '-s', '--swagger'], {
+  help:
+    'The swagger input file or URL. If not specified, it is required' +
+    ' that a configuration file called ' +
+    DEFAULT_CONFIG +
+    ' exist in the current directory, or a configuration file can be' +
+    ' specified with the -c or --config option.',
+  dest: 'swagger',
+  metavar: 'SWAGGER',
+});
+argParser.addArgument(['-o', '--output'], {
+  help: 'The root directory where files will be generated.',
+  dest: 'output',
+});
+argParser.addArgument(['-c', '--config'], {
+  help: 'Specifies the configuration file name.',
+  defaultValue: DEFAULT_CONFIG,
+  dest: 'config',
+});
+argParser.addArgument(['--gen-config'], {
+  help:
+    'Generates the configuration file ' +
+    DEFAULT_CONFIG +
+    ' in the current directory, or the file specified with -c or --config.' +
+    ' No Swagger client classes are generated.' +
+    ' If input and output are specified, their values are stored in the' +
+    ' generated file as well.',
+  action: 'storeTrue',
+  dest: 'genConfig',
+});
 var args = argParser.parseArgs();
 
 var config = args.config;
+var configPath = path.isAbsolute(config)
+  ? config
+  : path.join(process.cwd(), config);
 
 // Check the action
-var configExists = fs.existsSync(config);
+var configExists =
+  fs.existsSync(configPath) || fs.existsSync(configPath + '.js');
+
 if (args.genConfig) {
   if (configExists) {
     // Ask for confirmation
@@ -79,7 +79,7 @@ if (args.genConfig) {
 } else {
   if (configExists) {
     // The configuration file exists, so read it
-    const options = parseJSON(config);
+    const options = require(configPath);
     // Allow overriding both swagger and output via arguments
     if (args.swagger) {
       options.swagger = args.swagger;
@@ -93,7 +93,7 @@ if (args.genConfig) {
     run(args);
   } else {
     // No configuration file. Show the usage and exit.
-    argParser.parseArgs(["--help"]);
+    argParser.parseArgs(['--help']);
   }
 }
 
@@ -102,9 +102,9 @@ if (args.genConfig) {
  */
 function generateConfig() {
   var options = {
-    "$schema": "./node_modules/ng-swagger-gen/ng-swagger-gen-schema.json"
+    $schema: './node_modules/ng-swagger-gen/ng-swagger-gen-schema.json',
   };
-  options.swagger = args.swagger ? args.swagger : "<swagger file>";
+  options.swagger = args.swagger ? args.swagger : '<swagger file>';
   if (args.output) {
     options.output = args.output;
   }
@@ -113,17 +113,17 @@ function generateConfig() {
     var propDef = properties[propName];
     if (propDef.default && !options.hasOwnProperty(propName)) {
       var value = propDef.default;
-      if (propDef.type == "boolean") {
+      if (propDef.type == 'boolean') {
         value = value === 'true';
-      } else if (propDef.type == "integer") {
+      } else if (propDef.type == 'integer') {
         value = parseInt(value, 10);
       }
       options[propName] = value;
     }
   }
   var json = JSON.stringify(options, null, 2);
-  fs.writeFileSync(config, json, {encoding: "utf8"});
-  console.info("Wrote " + config);
+  fs.writeFileSync(config, json, { encoding: 'utf8' });
+  console.info('Wrote ' + config);
 }
 
 /**
@@ -133,22 +133,27 @@ function askThenGenerateConfig() {
   const readline = require('readline');
   const rl = readline.createInterface({
     input: process.stdin,
-    output: process.stdout
+    output: process.stdout,
   });
-  rl.question("The configuration file " + config + " already exists.\n" +
-    "Do you want to override it? [y/N]", (answer) => {
-    if (answer == 'y' || answer == 'Y') {
-      generateConfig();
-    }
-    rl.close();
-  });
+  rl.question(
+    'The configuration file ' +
+      config +
+      ' already exists.\n' +
+      'Do you want to override it? [y/N]',
+    answer => {
+      if (answer == 'y' || answer == 'Y') {
+        generateConfig();
+      }
+      rl.close();
+    },
+  );
 }
 
 /**
  * Runs the ng-swagger-gen generation
  */
 function run(options) {
-  var ngSwaggerGen = require("./ng-swagger-gen.js");
+  var ngSwaggerGen = require('./ng-swagger-gen.js');
   if (options.output == null) {
     options.output = schema.properties.output.default;
   }


### PR DESCRIPTION
By default CLI was only able to read configuration file from JSON.

This PR adds support to read configuration from the Javascript module that exports same format JSON object.

It allows consumers to have dynamic configurations that can be useful to read some Environment variables and pass them to CLI.