### PR TITLE
[bug] Proxy for Node.js starting from v10.16

### DIFF
--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const path = require('path');
 const Mustache = require('mustache');
 const $RefParser = require('json-schema-ref-parser');
+var npmConfig = require('npm-conf');
 
 /**
  * Main generate function
@@ -17,8 +18,7 @@ function ngSwaggerGen(options) {
     process.exit(1);
   }
 
-  var globalTunnel = require('global-tunnel-ng');
-  globalTunnel.initialize();
+  setupProxy();
   
   $RefParser.bundle(options.swagger, { dereference: { circular: false } }).then(
     data => {
@@ -32,6 +32,73 @@ function ngSwaggerGen(options) {
   ).catch(function (error) {
     console.error(`Error: ${error}`);
   });
+}
+
+/**
+ * Sets up the environment to work behind proxies.
+ * Uses global-agent from NodeJS >= 10,
+ * and global-tunnel-ng for previous versions.
+ */
+function setupProxy() {
+  var globalAgent = require('global-agent');
+  var globalTunnel = require('global-tunnel-ng');
+  var proxyAddress = getProxyAndSetupEnv();
+
+  const NODEJS_VERSION = parseInt(process.version.slice(1).split('.')[0], 10);
+  if (NODEJS_VERSION >= 10 && proxyAddress) {
+    // `global-agent` works with Node.js v10 and above.
+    globalAgent.bootstrap();
+    global.GLOBAL_AGENT.HTTP_PROXY = proxyAddress;
+  } else {
+    // `global-tunnel-ng` works only with Node.js v10 and below.
+    globalTunnel.initialize();
+  }
+}
+
+/**
+ * For full compatibility with globalTunnel we need to check a few places for
+ * the correct proxy address. Additionally we need to remove HTTP_PROXY
+ * and HTTPS_PROXY environment variables, if present.
+ * This is again for globalTunnel compatibility.
+ * 
+ * This method only needs to be run when global-agent is used
+ */
+function getProxyAndSetupEnv() {
+  var proxyEnvVariableNames = [
+    'https_proxy',
+    'HTTPS_PROXY',
+    'http_proxy',
+    'HTTP_PROXY'
+  ];
+
+  var npmVariableNames = ['https-proxy', 'http-proxy', 'proxy'];
+
+  var key;
+  var val;
+  var result;
+  for (var i = 0; i < proxyEnvVariableNames.length; i++) {
+    key = proxyEnvVariableNames[i];
+    val = process.env[key];
+    if (val) {
+      // Get the first non-empty
+      result = result || val;
+      // Delete all
+      // NB: we do it here to prevent double proxy handling
+      // (and for example path change)
+      // by us and the `request` module or other sub-dependencies
+      delete process.env[key];
+    }
+  }
+
+  if (!result) {
+    var config = npmConfig();
+
+    for (i = 0; i < npmVariableNames.length && !result; i++) {
+      result = config.get(npmVariableNames[i]);
+    }
+  }
+
+  return result;
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,11 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "boolean": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-1.0.0.tgz",
+      "integrity": "sha512-IB1lgIywn37N9Aff8CciCblVpMUflgL42vyxPUH0IvaDdIi/QwBHKv1lq/HOkATHCfa7c4MbMYJ7Bo7hGuoI+w=="
+    },
     "call-me-maybe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
@@ -26,6 +31,11 @@
         "proto-list": "~1.2.1"
       }
     },
+    "core-js": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
+      "integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
+    },
     "debug": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
@@ -39,6 +49,16 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+    },
+    "escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -48,6 +68,20 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
       "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
+    },
+    "global-agent": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.0.1.tgz",
+      "integrity": "sha512-2iGb96/51XxsekctZR4IiP7SoWuGEkmFpsyySasq3RFmvIwDCQJzatB2NqK0sk7h2hVYQdRphL52lrO5grF/jg==",
+      "requires": {
+        "boolean": "^1.0.0",
+        "core-js": "^3.1.4",
+        "es6-error": "^4.1.1",
+        "matcher": "^2.0.0",
+        "roarr": "^2.13.2",
+        "semver": "^6.2.0",
+        "serialize-error": "^4.1.0"
+      }
     },
     "global-tunnel-ng": {
       "version": "2.7.1",
@@ -85,10 +119,23 @@
         "ono": "^4.0.6"
       }
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "matcher": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-2.0.0.tgz",
+      "integrity": "sha512-nlmfSlgHBFx36j/Pl/KQPbIaqE8Zf0TqmSMjsuddHDg6PMSVgmyW9HpkLs0o0M1n2GIZ/S2BZBLIww/xjhiGng==",
+      "requires": {
+        "escape-string-regexp": "^2.0.0"
+      }
     },
     "ms": {
       "version": "2.1.1",
@@ -127,6 +174,42 @@
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
     },
+    "roarr": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.13.3.tgz",
+      "integrity": "sha512-f75w2kr46yWvV7tdnAFRzXiggNBaPrPAwai0Disa5NovRP5DtACrMrhr72Vot1ZNCDmMJ1hF7ix2Q5F+NJZwoA==",
+      "requires": {
+        "boolean": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+        }
+      }
+    },
+    "semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+    },
+    "serialize-error": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-4.1.0.tgz",
+      "integrity": "sha512-5j9GgyGsP9vV9Uj1S0lDCvlsd+gc2LEPVK7HHHte7IyPwOD4lVQFeaX143gx3U5AnoCi+wbcb3mvaxVysjpxEw==",
+      "requires": {
+        "type-fest": "^0.3.0"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -136,6 +219,11 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+    },
+    "type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
   },
   "dependencies": {
     "argparse": "^1.0.10",
+    "global-agent": "^2.0.1",
     "global-tunnel-ng": "^2.7.1",
     "json-schema-ref-parser": "^5.1.3",
-    "mustache": "^2.3.2"
+    "mustache": "^2.3.2",
+    "npm-conf": "^1.1.3"
   },
   "peerDependencies": {
     "@angular/core": ">=6.0.0",


### PR DESCRIPTION
As mentioned in #189 ,  Node.js users with a version above 10.15 that are behind a proxy will receive the following error message when trying to run ng-swagger-gen: `Cannot read property 'proxy' of undefined`

This is caused by `global-tunnel-ng`. The fix is to use `global-agent`.
However, there are a few compatibility concerns. `global-tunnel-ng` checks both the environment variables for proxies (and removes them if found) and the npm-config.

To not break existing implementation I took the configuration setup found in https://github.com/np-maintain/global-tunnel/blob/master/index.js, adapted it slightly and used it to setup `global-agent`.

This should keep compatibility with all users.