### PR TITLE
Handle multiple 2xx response types

### DIFF
--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -957,8 +957,14 @@ function processResponses(swagger, def, path, models) {
     var type = propertyType(response.schema);
     if (/2\d\d/.test(code)) {
       // Successful response
-      operationResponses.resultType = type;
-      operationResponses.resultDescription = response.description;
+      if (operationResponses.resultType) {
+        // More than one successful response, use union type
+        operationResponses.resultType += ` | ${type}`;
+        operationResponses.resultDescription += ` or ${response.description}`
+      } else {
+        operationResponses.resultType = type;
+        operationResponses.resultDescription = response.description;
+      }
       var headers = response.headers || {};
       for (var prop in headers) {
         // This operation returns at least one header


### PR DESCRIPTION
I am working on a project where some endpoints either return a 200 for a full success, or 207 for partial success. These return different data types, and these different data types are indicated in the swagger specification. However, as currently written, this swagger generator only accepts the last 2xx response and ignores all others. 

This PR will change the response type to be a union of all possible 2xx response types. Then, it is on the caller to determine from the response type which data type is actually being returned. This would basically be required for us to use ng-swagger-gen. 