### PR TITLE
Use propertyName instead of modelName to sort the modelProperties

### DIFF
--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -679,8 +679,8 @@ function processModels(swagger, options) {
         descriptor.modelProperties.push(property);
       }
       descriptor.modelProperties.sort((a, b) => {
-        return a.modelName < b.modelName ? -1 :
-          a.modelName > b.modelName ? 1 : 0;
+        return a.propertyName < b.propertyName ? -1 :
+          a.propertyName > b.propertyName ? 1 : 0;
       });
       if (descriptor.modelProperties.length > 0) {
         descriptor.modelProperties[


### PR DESCRIPTION
When sorting the properties of the model, the comparing function used ```modelName```. According to the ```processProperties``` function there can never be a property ```modelName```. Instead we should sort by ```propertyName```.

This fixes #209.