### PR TITLE
 [bug] fix html encoded objects

### DIFF
--- a/templates/object.mustache
+++ b/templates/object.mustache
@@ -4,6 +4,6 @@
 {{/modelProperties}}
 {{#modelAdditionalPropertiesType}}
 
-  [prop: string]: {{modelAdditionalPropertiesType}};
+  [prop: string]: {{{modelAdditionalPropertiesType}}};
 {{/modelAdditionalPropertiesType}}
 }

--- a/templates/object.mustache
+++ b/templates/object.mustache
@@ -3,7 +3,6 @@
 {{{propertyComments}}}{{&propertyName}}{{^propertyRequired}}?{{/propertyRequired}}: {{{propertyType}}};
 {{/modelProperties}}
 {{#modelAdditionalPropertiesType}}
-
   [prop: string]: {{{modelAdditionalPropertiesType}}};
 {{/modelAdditionalPropertiesType}}
 }


### PR DESCRIPTION
i've run into an issue, where this:

```json
// swagger.json

        "database.GroupMap": {
            "type": "object",
            "additionalProperties": {
                "type": "array",
                "items": {
                    "type": "object",
                    "properties": {
                        "id": {
                            "type": "integer"
                        },
                        "name": {
                            "type": "string"
                        }
                    }
                }
            }
        },
```

will result in:

```typescript
// app/src/api/models/database-group-map.ts

/* tslint:disable */
export interface DatabaseGroupMap {

  [prop: string]: Array&lt;{id?: number, name?: string}&gt;;
}
```

this PR fixes the broken encoded HTML output and removes the unneeded new line, so the interface will look like this:

```typescript
// // app/src/api/models/database-group-map.ts

/* tslint:disable */
export interface DatabaseGroupMap {
  [prop: string]: Array<{id?: number, name?: string}>;
}
```