### PR TITLE
Further fixes for allOf processing

### DIFF
--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -615,7 +615,10 @@ function processModels(swagger, options) {
       properties = (model.allOf.find(val => !!val.properties) || {}).properties || {};
       requiredProperties = (model.allOf.find(val => !!val.required) || {}).required || [];
       enumValues = model.enum || [];
-      if (enumValues.length == 0) {
+      if (parents && parents.length) {
+        simpleType = null;
+        enumValues = null;
+      } else if (enumValues.length == 0) {
         simpleType = 'string';
         enumValues = null;
       } else {
@@ -698,9 +701,9 @@ function processModels(swagger, options) {
     }
 
     // Process the hierarchy
-    var parentNames = model.modelParents;
-    if (parentNames && parentNames.length > 0) {
-      model.modelParents = parentNames
+    var parents = model.modelParents;
+    if (parents && parents.length > 0) {
+      model.modelParents = parents
         .filter(parentName => !!parentName)
         .map(parentName => {
         // Make the parent be the actual model, not the name
@@ -709,8 +712,13 @@ function processModels(swagger, options) {
         // Append this model on the parent's subclasses
         parentModel.modelSubclasses.push(model);
         return parentModel;
-      });
-      model.modelParents[0].parentIsFirst = true;
+        });
+      model.modelParentNames = model.modelParents.map(
+        (parent, index) => ({
+          modelClass: parent.modelClass,
+          parentIsFirst: index === 0,
+        })
+      );
     }
   }
 

--- a/templates/object.mustache
+++ b/templates/object.mustache
@@ -1,4 +1,4 @@
-{{{modelComments}}}export interface {{modelClass}} {{#modelParents}}{{#parentIsFirst}}extends {{/parentIsFirst}}{{^parentIsFirst}}, {{/parentIsFirst}}{{modelClass}}{{/modelParents}} {
+{{{modelComments}}}export interface {{modelClass}} {{#modelParentNames}}{{#parentIsFirst}}extends {{/parentIsFirst}}{{^parentIsFirst}}, {{/parentIsFirst}}{{modelClass}}{{/modelParentNames}} {
 {{#modelProperties}}
 {{{propertyComments}}}{{&propertyName}}{{^propertyRequired}}?{{/propertyRequired}}: {{{propertyType}}};
 {{/modelProperties}}


### PR DESCRIPTION
1. Use a separate list of model parent names.
  In the prior fix, the parentIsFirst property was not set properly, because it was set on the parent model object rather than the object itself. When there were more than one subclasses of a model it caused issues.
2.Updates to ensure that imports for parent classes are correctly set