### PR TITLE
Add injectable token provider fro authenticated endpoints

### DIFF
--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -24,20 +24,20 @@ function ngSwaggerGen(options) {
 
   $RefParser.bundle(options.swagger,
     { dereference: { circular: false },
-    resolve: { http: { timeout: options.timeout } } }).then(
-    data => {
-      doGenerate(data, options);
-    },
-    err => {
-      console.error(
-        `Error reading swagger location ${options.swagger}: ${err}`
-      );
+      resolve: { http: { timeout: options.timeout } } }).then(
+      data => {
+        doGenerate(data, options);
+      },
+      err => {
+        console.error(
+          `Error reading swagger location ${options.swagger}: ${err}`
+        );
+        process.exit(1);
+      }
+    ).catch(function (error) {
+      console.error(`Error: ${error}`);
       process.exit(1);
-    }
-  ).catch(function (error) {
-    console.error(`Error: ${error}`);
-    process.exit(1);
-  });
+    });
 }
 
 /**
@@ -121,7 +121,7 @@ function doGenerate(swagger, options) {
   if (swagger.swagger !== '2.0') {
     console.error(
       'Invalid swagger specification. Must be a 2.0. Currently ' +
-        swagger.swagger
+      swagger.swagger
     );
     process.exit(1);
   }
@@ -157,14 +157,14 @@ function doGenerate(swagger, options) {
   var fallbackTemplates = path.join(__dirname, 'templates');
   fs.readdirSync(fallbackTemplates)
     .forEach(function (file) {
-    var pos = file.indexOf('.mustache');
-    if (pos >= 0) {
-      var fullFile = path.join(fallbackTemplates, file);
-      if (!(file.substr(0, pos) in templates)) {
-        templates[file.substr(0, pos)] = fs.readFileSync(fullFile, 'utf-8');
+      var pos = file.indexOf('.mustache');
+      if (pos >= 0) {
+        var fullFile = path.join(fallbackTemplates, file);
+        if (!(file.substr(0, pos) in templates)) {
+          templates[file.substr(0, pos)] = fs.readFileSync(fullFile, 'utf-8');
+        }
       }
-    }
-  });
+    });
 
   // Prepare the output folder
   const modelsOutput = path.join(output, 'models');
@@ -248,7 +248,7 @@ function doGenerate(swagger, options) {
         var model = models[normalizeModelName(modelName)];
         if (basename == model.modelFile + '.ts'
           || basename == model.modelExampleFile + '.ts'
-            && model.modelExampleStr != null) {
+          && model.modelExampleStr != null) {
           ok = true;
           break;
         }
@@ -318,8 +318,8 @@ function doGenerate(swagger, options) {
   var fullModuleFile = path.join(output, moduleFile + '.ts');
   if (options.apiModule !== false) {
     generate(templates.module, applyGlobals({
-        services: servicesArray
-      }),
+      services: servicesArray
+    }),
       fullModuleFile);
   } else if (removeStaleFiles) {
     rmIfExists(fullModuleFile);
@@ -339,8 +339,8 @@ function doGenerate(swagger, options) {
     }
 
     generate(templates.configuration, applyGlobals({
-        rootUrl: rootUrl,
-      }),
+      rootUrl: rootUrl,
+    }),
       path.join(output, configurationFile + '.ts')
     );
   }
@@ -416,8 +416,8 @@ function applyTagFilter(models, services, options) {
         // This model is not used - remove it
         console.info(
           'Ignoring model ' +
-            modelName +
-            ' because it was not used by any service'
+          modelName +
+          ' because it was not used by any service'
         );
         delete models[normalizeModelName(modelName)];
       }
@@ -632,8 +632,8 @@ function processModels(swagger, options) {
       properties = (model.allOf.find(val => !!val.properties) || {}).properties || {};
       requiredProperties = (model.allOf.find(val => !!val.required) || {}).required || [];
       if (parents && parents.length) {
-          simpleType = null;
-          enumValues = null;
+        simpleType = null;
+        enumValues = null;
       }
     } else if (model.type === 'string') {
       enumValues = model.enum || [];
@@ -664,7 +664,7 @@ function processModels(swagger, options) {
       properties = model.properties || {};
       requiredProperties = model.required || [];
       additionalPropertiesType = model.additionalProperties &&
-          (typeof model.additionalProperties === 'object' ? propertyType(model.additionalProperties) : 'any');
+        (typeof model.additionalProperties === 'object' ? propertyType(model.additionalProperties) : 'any');
     } else {
       simpleType = propertyType(model);
     }
@@ -725,12 +725,12 @@ function processModels(swagger, options) {
       model.modelParents = parents
         .filter(parentName => !!parentName)
         .map(parentName => {
-        // Make the parent be the actual model, not the name
-        var parentModel =  models[normalizeModelName(parentName)];
+          // Make the parent be the actual model, not the name
+          var parentModel =  models[normalizeModelName(parentName)];
 
-        // Append this model on the parent's subclasses
-        parentModel.modelSubclasses.push(model);
-        return parentModel;
+          // Append this model on the parent's subclasses
+          parentModel.modelSubclasses.push(model);
+          return parentModel;
         });
       model.modelParentNames = model.modelParents.map(
         (parent, index) => ({
@@ -892,8 +892,8 @@ function propertyType(property) {
       if (Array.isArray(property.items)) { // support for tuples
         if (!property.maxItems) return 'Array<any>'; // there is unable to define unlimited tuple in TypeScript
         let minItems = property.minItems || 0,
-            maxItems = property.maxItems,
-            types = property.items.map(propertyType);
+          maxItems = property.maxItems,
+          types = property.items.map(propertyType);
         types.push(property.additionalItems ? propertyType(property.additionalItems) : 'any');
         let variants = [];
         for (let i = minItems; i <= maxItems; i++) variants.push(types.slice(0, i));
@@ -928,15 +928,15 @@ function propertyType(property) {
           if (memberCount++) def += ', ';
           type = propertyType(prop);
           allTypes.push(type);
-	        let required = property.required && property.required.indexOf(name) >= 0;
-	        def += name + (required ? ': ' : '?: ') + type;
+          let required = property.required && property.required.indexOf(name) >= 0;
+          def += name + (required ? ': ' : '?: ') + type;
         }
       }
       if (property.additionalProperties) {
         if (memberCount++) def += ', ';
         type = typeof property.additionalProperties === 'object' ?
-            propertyType(property.additionalProperties) : 'any';
-	      allTypes.push(type);
+          propertyType(property.additionalProperties) : 'any';
+        allTypes.push(type);
         def += '[key: string]: ' + type;
       }
       def += '}';
@@ -1103,25 +1103,25 @@ function operationId(given, method, url, allKnown) {
   if (generate) {
     console.warn(
       "Operation '" +
-        method +
-        "' on '" +
-        url +
-        "' defines no operationId. Assuming '" +
-        id +
-        "'."
+      method +
+      "' on '" +
+      url +
+      "' defines no operationId. Assuming '" +
+      id +
+      "'."
     );
   } else if (duplicated) {
     console.warn(
       "Operation '" +
-        method +
-        "' on '" +
-        url +
-        "' defines a duplicated operationId: " +
-        given +
-        '. ' +
-        "Assuming '" +
-        id +
-        "'."
+      method +
+      "' on '" +
+      url +
+      "' defines a duplicated operationId: " +
+      given +
+      '. ' +
+      "Assuming '" +
+      id +
+      "'."
     );
   }
   allKnown.add(id);
@@ -1139,7 +1139,7 @@ function processServices(swagger, models, options) {
   var sortParams = options.sortParams || 'desc';
   for (var url in swagger.paths) {
     var path = swagger.paths[url];
-	  var methodParameters = path.parameters;
+    var methodParameters = path.parameters;
     for (var method in path || {}) {
       var def = path[method];
       if (!def || method == 'parameters') {
@@ -1167,11 +1167,20 @@ function processServices(swagger, models, options) {
         descriptor.operationIds
       );
 
+      const hasBearerAuth = !!(def.security && (def.security.filter(v => v && v.hasOwnProperty('bearer'))).length > 0);
+
       var parameters = def.parameters || [];
 
       if (methodParameters) {
         parameters = parameters.concat(methodParameters);
       }
+
+      var tokenParameter = null;
+      if (hasBearerAuth) {
+        const tokenParameterIdx = parameters.findIndex(param => !!(param.in === 'header' && (param.name || '').match(/authorization/i)));
+        const param = parameters.splice(tokenParameterIdx, 1)[0];
+        tokenParameter = { paramName: param.name, paramIn: param.in };
+      } 
 
       var paramsClass = null;
       var paramsClassComments = null;
@@ -1197,6 +1206,7 @@ function processServices(swagger, models, options) {
         var paramDescriptor = {
           paramName: param.name,
           paramIn: param.in,
+          paramPlaceholderVar: 'paramValue_' + paramVar,
           paramVar: paramVar,
           paramFullVar: (paramsClass == null ? '' : 'params.') + paramVar,
           paramRequired: param.required === true || param.in === 'path',
@@ -1296,6 +1306,7 @@ function processServices(swagger, models, options) {
         operationHttpResponseType: '__StrictHttpResponse<' + resultType + '>',
         operationComments: toComments(docString, 1),
         operationParameters: operationParameters,
+        tokenParameter: tokenParameter,
         operationResponses: operationResponses,
       };
       var modelResult = models[normalizeModelName(removeBrackets(resultType))];
@@ -1319,13 +1330,13 @@ function processServices(swagger, models, options) {
       operation.operationIsByteArray = actualType === 'ArrayBuffer';
       operation.operationResponseType =
         operation.operationIsFile ? 'blob' :
-        operation.operationIsByteArray ? 'arraybuffer' :
-        operation.operationIsVoid ||
-        operation.operationIsString ||
-        operation.operationIsNumber ||
-        operation.operationIsBoolean ||
-        operation.operationIsEnum ?
-          'text' : 'json';
+          operation.operationIsByteArray ? 'arraybuffer' :
+            operation.operationIsVoid ||
+              operation.operationIsString ||
+              operation.operationIsNumber ||
+              operation.operationIsBoolean ||
+              operation.operationIsEnum ?
+              'text' : 'json';
       operation.operationIsUnknown = !(
         operation.operationIsVoid ||
         operation.operationIsString ||

--- a/templates/baseService.mustache
+++ b/templates/baseService.mustache
@@ -1,6 +1,7 @@
 /* tslint:disable */
 import { HttpClient, HttpParameterCodec, HttpParams } from '@angular/common/http';
 import { {{ configurationClass }} } from './{{configurationFile}}';
+import { Observable, of } from 'rxjs';
 
 /**
  * Custom parameter codec to correctly handle the plus sign in parameter

--- a/templates/operationResponse.mustache
+++ b/templates/operationResponse.mustache
@@ -11,17 +11,21 @@
     __body = __formData;{{/operationIsMultipart}}
 {{#operationParameters}}{{>parameter}}
 {{/operationParameters}}
-    let req = new HttpRequest<any>(
-      '{{operationMethod}}',
-      this.rootUrl + `{{{operationPathExpression}}}`,
-      __body,
-      {
-        headers: __headers,
-        params: __params,
-        responseType: '{{{operationResponseType}}}'
-      });
+    return {{#tokenParameter}}this.tokenProvider('{{paramName}}'){{/tokenParameter}}{{^tokenParameter}}__of(null){{/tokenParameter}}.pipe(
+      __switchMap(_token => {
+        {{#tokenParameter}}if (_token != null) __headers = __headers.set('{{paramName}}', _token.toString());
+        {{/tokenParameter}}let req = new HttpRequest<any>(
+          '{{operationMethod}}',
+          this.rootUrl + `{{{operationPathExpression}}}`,
+          __body,
+          {
+            headers: __headers,
+            params: __params,
+            responseType: '{{{operationResponseType}}}'
+          });
 
-    return this.http.request<any>(req).pipe(
+        return this.http.request<any>(req);
+      }),
       __filter(_r => _r instanceof HttpResponse),
       __map((_r) => {
         {{#operationIsVoid}}return (_r as HttpResponse<any>).clone({ body: null }) as {{{operationHttpResponseType}}}{{/operationIsVoid

--- a/templates/service.mustache
+++ b/templates/service.mustache
@@ -1,11 +1,17 @@
 /* tslint:disable */
-import { Injectable } from '@angular/core';
+import { Injectable, InjectionToken, Optional, Inject } from '@angular/core';
 import { HttpClient, HttpRequest, HttpResponse, HttpHeaders } from '@angular/common/http';
 import { BaseService as __BaseService } from '../base-service';
 import { {{ configurationClass }} as __Configuration } from '../{{configurationFile}}';
 import { StrictHttpResponse as __StrictHttpResponse } from '../strict-http-response';
-import { Observable as __Observable } from 'rxjs';
-import { map as __map, filter as __filter } from 'rxjs/operators';
+import { Observable as __Observable, of as __of } from 'rxjs';
+import { map as __map, filter as __filter, switchMap as __switchMap } from 'rxjs/operators';
+
+interface {{serviceClass}}TokenProvider {
+  getToken: (name: string) => __Observable<string>;
+}
+
+const {{serviceClass}}TokenProviderInjectionToken = new InjectionToken<{{serviceClass}}TokenProvider>('{{serviceClass}}TokenProviderInjectionToken')
 
 {{#serviceDependencies}}import { {{modelClass}} } from '../models/{{modelFile}}';
 {{/serviceDependencies}}
@@ -15,12 +21,19 @@ import { map as __map, filter as __filter } from 'rxjs/operators';
 class {{serviceClass}} extends __BaseService {
 {{#serviceOperations}}{{>operationEndpoints}}{{/serviceOperations}}
 
+  private tokenProvider: (name: string) => __Observable<string> = _ => __of(null);
+
   constructor(
     config: __Configuration,
-    http: HttpClient
+    http: HttpClient,
+    @Optional() @Inject({{serviceClass}}TokenProviderInjectionToken) tokenProvider: {{serviceClass}}TokenProvider,
   ) {
     super(config, http);
+    if (tokenProvider) {
+      this.tokenProvider = (v: string) => tokenProvider.getToken(v);
+    }
   }
+
 {{#serviceOperations}}{{>operationResponse}}{{>operationBody}}{{/serviceOperations}}
 }
 
@@ -34,4 +47,4 @@ module {{serviceClass}} {
 {{/operationParamsClass}}{{/serviceOperations}}
 }
 
-export { {{serviceClass}} }
+export { {{serviceClass}}, {{serviceClass}}TokenProvider, {{serviceClass}}TokenProviderInjectionToken }

--- a/templates/services.mustache
+++ b/templates/services.mustache
@@ -1,3 +1,3 @@
 {{#services}}
-export { {{serviceClass}} } from './services/{{serviceFile}}';
+export { {{serviceClass}}, {{serviceClass}}TokenProvider, {{serviceClass}}TokenProviderInjectionToken } from './services/{{serviceFile}}';
 {{/services}}


### PR DESCRIPTION
Hi, we have a scenario where some of our endpoints are secured and some are not.

Using the interceptor pattern leaves us unable to determine if we should add the authorize header or not. As a solution I added an injectable angular token provider.

Basically... if there are "authorization" header values AND the auth type is set to bearer in the swagger file it won't include those as params that are needed to be provided by the API consumer, and will instead try to fetch the token using the api token provider as needed. Additionally, we have two different types of auth tokens `authorization` and `device-authorization` so this enables us to provide the correct token based on what the endpoint defines in the swagger file.

With this pattern we only append the auth header if it is required, and the individual places that we call the api service don't need to have or even know about the token.

This could be merged as-is, but I think it'd cause some breaking changes for anyone depending on sending auth tokens as a param. Perhaps i can be a cli flag?

We're using the forked version as-is, but I just wanted to push this change upstream in case you'd like to incorporate it or if anyone else may need similar functionality.

Usage...

add this to your app module

```
{ provide: ApiServiceTokenProviderInjectionToken, useClass: ApiTokenProviderServiceService },
```

create a provider service like this...

```
@Injectable()
export class ApiTokenProviderServiceService implements ApiServiceTokenProvider {

  getToken(name: string): Observable<string> {
    switch (name) {
      case 'authorization':
        // TODO: get token from wherever it is stored
        return of('');
      case 'device-authorization':
        // optional secondary auth types
        return of('');
      default:
        // unknown auth type
        return of(null);
    }
  }
}
```

