### PR TITLE
deprecation jsdoc

### DIFF
--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -1250,6 +1250,9 @@ function processServices(swagger, models, options) {
           docString = summary + '\n\n' + docString;
         }
       }
+      if (def.deprecated) {
+          docString += '\n@deprecated';
+      }
       if (paramsClass == null) {
         for (i = 0; i < operationParameters.length; i++) {
           param = operationParameters[i];


### PR DESCRIPTION
reasoning: at moment we can mark endpoint as deprecated in spec but clients wont even notice that

with that change generated service method will have `@deprecated` comment which at least will allow different linters to take care

![image](https://user-images.githubusercontent.com/88868/95882066-ecd11600-0d81-11eb-8c34-a75e3f52e6f0.png)
